### PR TITLE
Add assert

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,28 @@ class Main
 }
 ```
 
+## Assertions
+Each log priority has an `assert`, which has a variety of standard assertion methods like `isTrue(someBool)` or `equals(someInt, 5)` which will log if untrue. You can also call `assert` directly with a condition and it will output the condition's expression in the logged message. For example:
+```hx
+final log = Logger.log;
+log.error.throws = false;
+
+// Check bool
+final condition = false;
+log.error.assert.isTrue(condition); // Error: Expected true, found false
+
+final a = 5;
+
+// check equality
+log.error.assert.equals(a, 10); // Error: Expected 10, found 5
+
+// check expression
+log.error.assert(a == 10); // Error: Assertion failed: a == 10
+
+// shorter equivalent
+log.assert(a == 10); // Error: Assertion failed: a == 10
+```
+
 ## Enabling logs via compile flags
 While the `Logger` constructor has `priority` and `throwPriority` args, these can be overriden from compiler flags, by adding the flag `-D log=WARN` all log priorities less than `WARN` (i.e.: `INFO` and `VERBOSE`) are disabled. You can also specify exactly which priorities are enabled, for example, `-D log=[info,error]` will disable all priorities other than `INFO` and `ERROR`. The `log` flag will also effect all categories, unless the category has it's own log priorities set in compiler flags. For example, a logger with the id "Combat" can have its log priorities set via `-D combat.log=error`. There is a similar `throw` flag to specify which logs throw an exception
 

--- a/haxelib.json
+++ b/haxelib.json
@@ -1,10 +1,10 @@
 { "name"        : "logger"
-, "description" : "Simplify the categorization and prioritization of logs."
+, "description" : "Simplify the categorization and prioritization of logs, errors and assertions."
 , "version"     : "0.0.0"
 , "releasenote" : "Initial release"
 , "url"         : "https://github.com/Geokureli/Logger"
 , "classPath"   : "lib"
 , "license"     : "MIT"
-, "tags"        : ["log", "logging", "trace"]
+, "tags"        : ["log", "logging", "trace", "assert"]
 , "contributors": ["GeoKureli"]
 }

--- a/lib/debug/Assert.hx
+++ b/lib/debug/Assert.hx
@@ -1,0 +1,246 @@
+package debug;
+
+import haxe.PosInfos;
+import haxe.macro.Expr;
+import haxe.macro.ExprTools;
+import haxe.macro.MacroStringTools;
+
+@:forward
+abstract Assert(AssertRaw)
+{
+    public function new(fail:(String, ?PosInfos)->Void):Void
+    {
+        this = new AssertRaw(fail);
+    }
+    
+    @:op(a())
+    macro public function eval(expr:ExprOf<Bool>, args:Array<Expr>):Expr
+    {
+        return AssertRaw.eval(expr, args);
+    }
+}
+/**
+ * Various assert methods
+ * @author George
+ */
+ @:allow(debug.Logger)
+ @:allow(debug.Assert)
+class AssertRaw
+{
+    /**
+     * Called by failed asserts, throws an error by default. 
+     * Can be redirected to any function.
+     * 
+     * @example myAssert.fail = haxe.Log.trace;    myAssert.isTrue(false, "test");// output: test
+     * 
+     * @param msg  An optional error message. If not passed a default one will be used
+     */
+    public var fail(default, null):(msg:String, ?pos:PosInfos)->Void;
+    
+    function new(fail:(String, ?PosInfos)->Void):Void
+    {
+        if (fail != null)
+            this.fail = fail;
+    }
+    
+    function destroy()
+    {
+        fail = null;
+    }
+    
+    // macro public function expr(expression:ExprOf<Bool>):Expr
+    // {
+    //     return getMsg(expression);
+    // }
+    
+    @:op(a())
+    inline public function isTrue(cond:Bool, ?msg:String, ?pos:PosInfos):Bool
+    {
+        if (!cond)
+            fail(msg ?? 'Expected true, got false', pos);
+        
+        return cond;
+    }
+    
+    inline public function isFalse(cond:Bool, ?msg:String, ?pos:PosInfos):Bool
+    {
+        return isTrue(!cond, 'Expected false, got true', pos);
+    }
+    
+    inline public function isNull(value:Dynamic, ?msg:String, ?pos:PosInfos):Bool
+    {
+        return isTrue(value == null, msg ?? 'Expected null, got ${q(value)}', pos);
+    }
+    
+    inline public function nonNull(value:Dynamic, ?msg:String, ?pos:PosInfos):Bool
+    {
+        return isTrue(value != null, msg ?? 'Unexpected null', pos);
+    }
+    
+    //@:generic
+    inline public function exists<K, T>(map:Map<K, T>, key:K, ?msg:String, ?pos:PosInfos):Bool
+    {
+        return nonNull(map, null, pos) 
+            && isTrue(map.exists(key), msg ?? 'Could not find key ${Std.string(key)}', pos);
+    }
+    
+    //@:generic
+    inline public function notExists<K, T>(map:Map<K, T>, key:K, ?msg:String, ?pos:PosInfos):Bool
+    {
+        return nonNull(map, null, pos)
+            && isTrue(!map.exists(key), msg ?? 'Unexpected key ${Std.string(key)}', pos);
+    }
+    
+    inline public function has(object:Dynamic, field:String, ?msg:String, ?pos:PosInfos):Bool
+    {
+        return nonNull(object, null, pos)
+            && isTrue(Reflect.hasField(object, field), msg ?? 'Could not find field $field', pos);
+    }
+    
+    inline public function missing(object:Dynamic, field:String, ?msg:String, ?pos:PosInfos):Bool
+    {
+        return nonNull(object, null, pos)
+            && isTrue(!Reflect.hasField(object, field), msg ?? 'Unexpected field $field', pos);
+    }
+    
+    inline public function is(value:Dynamic, type:Dynamic, ?msg:String, ?pos:PosInfos):Bool
+    {
+        return isTrue(Std.isOfType(value, type),
+            msg ?? 'Expected type ${typeToString(type)}, found ${typeToString(value)}', pos);
+    }
+    
+    inline public function isNot(value:Dynamic, type:Dynamic, ?msg:String, ?pos:PosInfos):Bool
+    {
+        return isTrue(!Std.isOfType(value, type), msg ?? 'Unexpected type ${typeToString(type)}', pos);
+    }
+    
+    inline public function isObject(value:Dynamic, ?msg:String, ?pos:PosInfos):Bool
+    {
+        return isTrue(Reflect.isObject(value), msg ?? "Expected Object type", pos);
+    }
+    
+    inline public function equals(value:Dynamic, expected:Dynamic, ?msg:String, ?pos:PosInfos):Bool
+    {
+        return isTrue(expected == value, msg ?? 'Expected ${q(expected)}, found ${q(value)}', pos);
+    }
+    
+    inline public function notEquals(value:Dynamic, expected:Dynamic, ?msg:String, ?pos:PosInfos):Bool
+    {
+        return isTrue(value != expected,
+            msg ?? 'Expected ${q(expected)} and test value ${q(value)} should be different', pos);
+    }
+    
+    inline public function match(pattern:EReg, value:Dynamic, ?msg:String, ?pos:PosInfos):Bool
+    {
+        return isTrue(pattern.match(value), msg ?? '${q(value)} does not match the provided pattern', pos);
+    }
+    
+    inline public function floatEquals(value:Float, expected:Float, approx:Float = 1e-5, ?msg:String, ?pos:PosInfos):Bool
+    {
+        return isTrue(compareFloats(expected, value, approx),
+            msg ?? 'Expected ${q(expected)}, found ${q(value)}', pos);
+    }
+    
+    function compareFloats(value:Float, expected:Float, approx:Float):Bool
+    {
+        if (Math.isNaN(expected))
+            return Math.isNaN(value);
+        
+        if (Math.isNaN(value))
+            return false;
+        
+        if (!Math.isFinite(expected) && !Math.isFinite(value))
+            return (expected > 0) == (value > 0);
+        
+        return Math.abs(value - expected) <= approx;
+    }
+    
+    inline public function contains<T>(list:Iterable<T>, item:T, ?msg:String, ?pos:PosInfos):Bool
+    {
+        return isTrue(Lambda.has(list, item), msg ?? 'Couldn\'t find ${item} in ${q(list)}', pos);
+    }
+    
+    inline public function notContains<T>(list:Array<T>, item:T, ?msg:String, ?pos:PosInfos):Bool
+    {
+        return isTrue(!Lambda.has(list, item), msg ?? 'Found unexpected ${item} in ${q(list)}', pos);
+    }
+    
+    inline public function stringContains(str:String, token:String, ?msg:String, ?pos:PosInfos):Bool
+    {
+        return isTrue(str != null && str.indexOf(token) >= 0,
+            msg ?? 'String ${q(str)} do not contain ${token}', pos);
+    }
+    
+    // =============================================================================
+    //{ region                            HELPERS
+    // =============================================================================
+    
+    function typeToString(t:Dynamic):String
+    {
+        try
+        {
+            final _t = Type.getClass(t);
+            
+            if (_t != null)
+                t = _t;
+            
+        }
+        catch(e:Dynamic) { }
+        
+        try return Type.getClassName(t) catch (e:Dynamic) { }
+        
+        try
+        {
+            final _t = Type.getEnum(t);
+            
+            if (_t != null)
+                t = _t;
+            
+        }
+        catch(e:Dynamic) { }
+        
+        try return Type.getEnumName(t)        catch (e:Dynamic) { }
+        try return Std.string(Type.typeof(t)) catch (e:Dynamic) { }
+        try return Std.string(t)              catch (e:Dynamic) { }
+        
+        return "<Unknown Type>";
+    }
+    
+    /** Wraps in quotes */
+    inline function q(v:Dynamic):String
+    {
+        if (Std.isOfType(v, String))
+            v = '"' + StringTools.replace(v, '"', '\\"') + '"';
+        
+        return Std.string(v);
+    }
+    
+    //} endregion                         HELPERS
+    // =============================================================================
+    
+    
+    #if macro
+    static public function eval(instance:Expr, args:Array<Expr>):Expr
+    {
+        if (args.length == 1)
+            return evalFinal(instance, args[0]);
+        
+        if (args.length == 2)
+            return evalFinal(instance, args[0], args[1]);
+        
+        throw "Invalid number of args";
+    }
+    
+    static function evalFinal(instance:Expr, cond:ExprOf<Bool>, ?msg:ExprOf<String>):Expr
+    {
+        final formatted = msg
+            ?? MacroStringTools.formatString('Assertion failed: ${ExprTools.toString(cond)}', cond.pos);
+        
+        return macro
+        {
+            @:pos(cond.pos)
+            $instance.isTrue($cond, $formatted);
+        };
+    }
+    #end
+}

--- a/lib/debug/Logger.hx
+++ b/lib/debug/Logger.hx
@@ -43,6 +43,12 @@ abstract Logger(LoggerRaw) from LoggerRaw
      */
     static public final log = new Logger(VERBOSE);
     
+    static public var assert(get, never):Assert;
+    static inline function get_assert():Assert
+    {
+        return log.assert;
+    }
+    
     /**
      * Controls how each every Logger will actually log the message, this can also be set for each
      * individual logger with:

--- a/lib/debug/Logger.hx
+++ b/lib/debug/Logger.hx
@@ -59,7 +59,7 @@ abstract Logger(LoggerRaw) from LoggerRaw
         haxe.Log.trace(msg, pos);
     }
     
-    dynamic static public function globalFormatter(id:String, priority:Priority, msg:Any, ?pos:PosInfos)
+    dynamic static public function globalFormatter(id:Null<String>, priority:Priority, msg:Any, ?pos:PosInfos)
     {
         return if (id != null && priority != NONE)
             '$id[$priority]: $msg';

--- a/lib/debug/Logger.hx
+++ b/lib/debug/Logger.hx
@@ -1,5 +1,6 @@
 package debug;
 
+import debug.Assert;
 import haxe.PosInfos;
 
 /**
@@ -33,7 +34,7 @@ import haxe.PosInfos;
  * - `-D combat.log=verbose`: Enable ALL logs with the id "Combat" (not case sensitive), overrides global log-priority
  */
 @:forward
-abstract Logger(LoggerRaw)
+abstract Logger(LoggerRaw) from LoggerRaw
 {
     /**
      * The default logger, able to be referenced anywhere
@@ -95,6 +96,15 @@ private class LoggerRaw
     
     final logLevels:PriorityList;
     final throwLevels:PriorityList;
+    
+    /**
+     * Shortcut for `error.assert`
+     */
+    public var assert(get, never):Assert;
+    inline function get_assert():Assert
+    {
+        return error.assert;
+    }
     
     /** Meant to be called, directly like a function, but also has an `enabled` and `throws` field */
     public final error:LoggerPriority;
@@ -186,60 +196,6 @@ private class LoggerRaw
         
         if (logEnabled(level))
             logFinal(level, msg, pos);
-    }
-}
-
-@:forward(enabled, throws)
-abstract LoggerPriority(LoggerPriorityRaw)
-{
-    public function new(parent, level)
-    {
-        this = new LoggerPriorityRaw(parent, level);
-    }
-    
-    @:op(a())
-    inline function callPos(msg:Any, ?pos:PosInfos)
-    {
-        this.log(msg, pos);
-    }
-    
-    @:allow(debug.LoggerRaw)
-    inline function destroy()
-    {
-        this.destroy();
-    }
-}
-
-@:allow(debug.LoggerPriority)
-private class LoggerPriorityRaw
-{
-    var parent:LoggerRaw;
-    final level:Priority;
-    
-    /** Whether this log level is enabled */
-    public var enabled(get, set):Bool;
-    inline function get_enabled() return parent.logEnabled(level);
-    inline function set_enabled(value:Bool) return parent.setLogEnabled(level, value);
-    
-    /** Whether this log level is set to throw exceptions when called */
-    public var throws(get, set):Bool;
-    inline function get_throws() return parent.throwEnabled(level);
-    inline function set_throws(value:Bool) return parent.setThrowEnabled(level, value);
-    
-    public function new(parent:LoggerRaw, level:Priority)
-    {
-        this.parent = parent;
-        this.level = level;
-    }
-    
-    public function destroy()
-    {
-        parent = null;
-    }
-    
-    function log(msg:Any, ?pos:PosInfos):Void
-    {
-        parent.logIf(level, msg, pos);
     }
 }
 

--- a/lib/debug/Logger.hx
+++ b/lib/debug/Logger.hx
@@ -43,6 +43,11 @@ abstract Logger(LoggerRaw) from LoggerRaw
      */
     static public final log = new Logger(VERBOSE);
     
+    /**
+     * Shortcut for `Logger.log.error.assert`
+     * 
+     * Tip: Use `import.debug.Logger.assert;` in a module to simplfy your calls
+     */
     static public var assert(get, never):Assert;
     static inline function get_assert():Assert
     {
@@ -59,6 +64,9 @@ abstract Logger(LoggerRaw) from LoggerRaw
         haxe.Log.trace(msg, pos);
     }
     
+    /**
+     * Set this to make a custom log formatter, and log will use this to format it's information
+     */
     dynamic static public function globalFormatter(id:Null<String>, priority:Priority, msg:Any, ?pos:PosInfos)
     {
         return if (id != null && priority != NONE)

--- a/lib/debug/LoggerPriority.hx
+++ b/lib/debug/LoggerPriority.hx
@@ -1,0 +1,65 @@
+package debug;
+
+import debug.Logger;
+import haxe.PosInfos;
+
+@:forward(enabled, throws, assert)
+abstract LoggerPriority(LoggerPriorityRaw)
+{
+    public function new(parent, level)
+    {
+        this = new LoggerPriorityRaw(parent, level);
+    }
+    
+    @:op(a())
+    inline function callPos(msg:Any, ?pos:PosInfos)
+    {
+        this.log(msg, pos);
+    }
+    
+    @:allow(debug.LoggerRaw)
+    inline function destroy()
+    {
+        this.destroy();
+    }
+}
+
+@:allow(debug.LoggerPriority)
+private class LoggerPriorityRaw
+{
+    var parent:Logger;
+    final level:Priority;
+    
+    public var assert(default, null):Assert;
+    
+    /** Whether this log level is enabled */
+    public var enabled(get, set):Bool;
+    inline function get_enabled() @:privateAccess return parent.logEnabled(level);
+    inline function set_enabled(value:Bool) @:privateAccess return parent.setLogEnabled(level, value);
+    
+    /** Whether this log level is set to throw exceptions when called */
+    public var throws(get, set):Bool;
+    inline function get_throws() @:privateAccess return parent.throwEnabled(level);
+    inline function set_throws(value:Bool) @:privateAccess return parent.setThrowEnabled(level, value);
+    
+    public function new(parent:Logger, level:Priority)
+    {
+        this.parent = parent;
+        this.level = level;
+        
+        assert = new Assert((?s, ?p)->log(s, p));
+    }
+    
+    public function destroy()
+    {
+        parent = null;
+        @:privateAccess 
+        assert.destroy();
+    }
+    
+    function log(msg:Any, ?pos:PosInfos):Void
+    {
+        @:privateAccess
+        parent.logIf(level, msg, pos);
+    }
+}

--- a/test/src/Main.hx
+++ b/test/src/Main.hx
@@ -1,4 +1,5 @@
 import debug.Logger.log as gLog;
+import debug.Logger.assert as gAssert;
 class Main
 {
     static public var log = new debug.Logger("Special", WARN, ERROR); // logs warnings, throws exceptions on errors
@@ -43,5 +44,13 @@ class Main
         gLog.warn("test log");
         gLog.info("test log");
         gLog.verbose("test log");
+        try
+        {
+            gAssert(5 < 3); // throws exception
+        }
+        catch(e)
+        {
+            gLog('exception thrown: ${e.message}'); // Output: exception thrown: Special[ERROR]:test log
+        }
     }
 }

--- a/test/src/Main.hx
+++ b/test/src/Main.hx
@@ -20,6 +20,19 @@ class Main
         {
             gLog('exception thrown: ${e.message}'); // Output: exception thrown: Special[ERROR]:test log
         }
+        
+        // asserts
+        log.verbose.assert(5 < 3);
+        log.info.assert(5 < 3);
+        log.warn.assert(5 < 3);
+        try
+        {
+            log.assert(5 < 3); // throws exception
+        }
+        catch(e)
+        {
+            gLog('exception thrown: ${e.message}'); // Output: exception thrown: Special[ERROR]:test log
+        }
         // set custom logger
         log.formatter = (priority, msg, ?pos) -> 'SPECIAL_$priority:$msg';
         log.error.throws = false;


### PR DESCRIPTION
Adds assert to each log priority. From the readme:

## Assertions
Each log priority has an `assert`, which has a variety of standard assertion methods like `isTrue(someBool)` or `equals(someInt, 5)` which will log if untrue. You can also call `assert` directly with a condition and it will output the condition's expression in the logged message. For example:
```hx
final log = Logger.log;
log.error.throws = false;

// Check bool
final condition = false;
log.error.assert.isTrue(condition); // Error: Expected true, found false

final a = 5;

// check equality
log.error.assert.equals(a, 10); // Error: Expected 10, found 5

// check expression
log.error.assert(a == 10); // Error: Assertion failed: a == 10

// shorter equivalent
log.assert(a == 10); // Error: Assertion failed: a == 10
```

## To Do
- [x] doc