### PR TITLE
Sub categories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.DS_Store
+export/

--- a/README.md
+++ b/README.md
@@ -84,9 +84,27 @@ log.assert(a == 10); // Error: Assertion failed: a == 10
 ## Enabling logs via compile flags
 While the `Logger` constructor has `priority` and `throwPriority` args, these can be overriden from compiler flags, by adding the flag `-D log=WARN` all log priorities less than `WARN` (i.e.: `INFO` and `VERBOSE`) are disabled. You can also specify exactly which priorities are enabled, for example, `-D log=[info,error]` will disable all priorities other than `INFO` and `ERROR`. The `log` flag will also effect all categories, unless the category has it's own log priorities set in compiler flags. For example, a logger with the id "Combat" can have its log priorities set via `-D combat.log=error`. There is a similar `throw` flag to specify which logs throw an exception
 
+## Subcategories
+Categories can have subcategories, useful for specific logs that pertain to a larger category, but requires a different priority than the rest. For example:
+```hx
+final playerLog = new debug.Logger("Player", INFO);
+final enemyLog = new debug.Logger("Enemy", INFO);
+
+playerLog.sub("Sound").info("Playing jump sound"); // Player.Sound[INFO]: Playing jump sound
+enemyLog.sub("Sound").warn("Not playing any sound"); // Enemy.Sound[WARN]: Not playing any sound
+```
+
+Subcategories will have the same level as the parent by default, but can also be set by compiler flags matching the subcategories id or the full "parent.sub" id. In the example above, `-D player.sound.log=verbose` will affect the player's sound logs, but not enemies, and `-D sound.log=verbose` will affect both. If both of the following compiler flags are set, all sound logs will be hidden except player sound logs:
+```hxml
+-D player.sound.log=verbose
+-D sound.log=none
+```
+
 ### Quick overview
  - `-D log=WARN`: Set global log-priority to warnings and errors
  - `-D throw=ERROR`: Set global throw-priority to errors
  - `-D log=[info,error]`: Only log info and errors, not warnings and verbose
  - `-D combat.log=verbose`: Enable ALL logs with the id "Combat" (not case sensitive), overrides global log-priority
+ - `-D sound.log=error`: Override all sound subcategories
+ - `-D combat.sound.log=warn`: Override combat's log priority specifically for all sound related logs
  

--- a/lib/debug/Logger.hx
+++ b/lib/debug/Logger.hx
@@ -41,7 +41,7 @@ abstract Logger(LoggerRaw) from LoggerRaw
      * 
      * Tip: Use `import.debug.Logger.log;` in a module to simplfy your calls
      */
-    static public final log = new Logger(VERBOSE);
+    static public final log:Logger = LoggerRaw.fromLevels(null, VERBOSE);
     
     /**
      * Shortcut for `Logger.log.error.assert`
@@ -79,6 +79,8 @@ abstract Logger(LoggerRaw) from LoggerRaw
             '$msg';
     }
     
+    static final list = new Map<String, LoggerRaw>();
+    
     /**
      * Creates a new logger
      * 
@@ -90,7 +92,20 @@ abstract Logger(LoggerRaw) from LoggerRaw
      */
     inline public function new(?id, priority = WARN, throwPriority = ERROR)
     {
-        this = LoggerRaw.fromLevels(id, priority, throwPriority);
+        if (id == null)
+        {
+            this = (cast Logger.log: LoggerRaw);
+        }
+        else if (list.exists(id))
+        {
+            // Note: do not set priority again
+            this = list[id];
+        }
+        else
+        {
+            this = LoggerRaw.fromLevels(id, priority, throwPriority);
+            list[id] = this;
+        }
     }
     
     @:op(a())
@@ -99,9 +114,23 @@ abstract Logger(LoggerRaw) from LoggerRaw
         this.log(msg, pos);
     }
     
-    inline public function sub(subID:String):Logger
+    /**
+     * Creates a sub-category of this category, capable of having its own priorities.
+     * By default, the priorities will match this, unless specifically set via compile flags
+     * 
+     * @param   subID  The id of the sub category
+     * @return  A different logger
+     */
+    public function sub(subID:String):Logger
     {
-        return this.sub(subID);
+        if (this.id == null)
+            return new Logger(subID);
+        
+        final fullID = '${this.id}.$subID';
+        if (list.exists(fullID))
+            return list[fullID];
+        
+        return list[fullID] = LoggerRaw.fromParent(subID, this);
     }
 }
 
@@ -218,16 +247,7 @@ private class LoggerRaw
             logFinal(level, msg, pos);
     }
     
-    final subs = new Map<String, LoggerRaw>();
-    public function sub(subID:String)
-    {
-        if (false == subs.exists(subID))
-            subs[subID] = LoggerRaw.fromParent(subID, this);
-        
-        return subs[subID];
-    }
-    
-    static public function fromLevels(id:String, logLevel = WARN, throwLevel = ERROR)
+    static public function fromLevels(id:Null<String>, logLevel = WARN, throwLevel = ERROR)
     {
         return new LoggerRaw(id, PriorityList.fromPriority(logLevel), PriorityList.fromPriority(throwLevel));
     }

--- a/lib/debug/Logger.hx
+++ b/lib/debug/Logger.hx
@@ -88,15 +88,20 @@ abstract Logger(LoggerRaw) from LoggerRaw
      * @param   priority       Determines the lowest priority to be logged
      * @param   throwPriority  Determines the lowest priority to throw exceptions
      */
-    public function new(?id, priority = WARN, throwPriority = ERROR)
+    inline public function new(?id, priority = WARN, throwPriority = ERROR)
     {
-        this = new LoggerRaw(id, priority, throwPriority);
+        this = LoggerRaw.fromLevels(id, priority, throwPriority);
     }
     
     @:op(a())
     inline function callPos(msg:Any, ?pos:PosInfos)
     {
         this.log(msg, pos);
+    }
+    
+    inline public function sub(subID:String):Logger
+    {
+        return this.sub(subID);
     }
 }
 
@@ -132,7 +137,7 @@ private class LoggerRaw
     /** Meant to be called, directly like a function, but also has an `enabled` and `throws` field */
     public final verbose:LoggerPriority;
     
-    public function new(?id, priority = WARN, throwPriority = ERROR)
+    public function new(?id, priority:PriorityList, throwPriority:PriorityList)
     {
         this.id = id;
         logLevels = PriorityList.fromCompilerFlag(LOG, id, priority);
@@ -162,6 +167,7 @@ private class LoggerRaw
         Logger.globalLog(formatter(priority, msg, pos), pos);
     }
     
+    // TODO: public var formatter = Logger.globalFormatter;
     dynamic public function formatter(priority:Priority, msg:Any, ?pos:PosInfos)
     {
         return Logger.globalFormatter(id, priority, msg, pos);
@@ -211,6 +217,27 @@ private class LoggerRaw
         if (logEnabled(level))
             logFinal(level, msg, pos);
     }
+    
+    final subs = new Map<String, LoggerRaw>();
+    public function sub(subID:String)
+    {
+        if (false == subs.exists(subID))
+            subs[subID] = LoggerRaw.fromParent(subID, this);
+        
+        return subs[subID];
+    }
+    
+    static public function fromLevels(id:String, logLevel = WARN, throwLevel = ERROR)
+    {
+        return new LoggerRaw(id, PriorityList.fromPriority(logLevel), PriorityList.fromPriority(throwLevel));
+    }
+    
+    static public function fromParent(subID:String, parent:LoggerRaw)
+    {
+        final logger = new LoggerRaw('${parent.id}.$subID', parent.logLevels, parent.throwLevels);
+        // logger.formatter = parent.formatter;
+        return logger;
+    }
 }
 
 abstract PriorityList(Array<Priority>) from Array<Priority>
@@ -219,6 +246,12 @@ abstract PriorityList(Array<Priority>) from Array<Priority>
     {
         this = levels;
     }
+    
+    public function copy()
+    {
+        return this.copy();
+    }
+    
     
     public function setPriority(priority:Priority)
     {
@@ -302,26 +335,83 @@ abstract PriorityList(Array<Priority>) from Array<Priority>
         return fromCompilerFlagHelper(type, id, fromPriority(backup));
     }
     
-    overload inline extern static public function fromCompilerFlag(type, id, backup)
+    overload inline extern static public function fromCompilerFlag(type, id, backup:PriorityList)
     {
         return fromCompilerFlagHelper(type, id, backup);
     }
     
+    static final flagsByID = new Map<String, Null<String>>();
+    
+    inline static var SUB_DELIMITER = ".";
+    static final contextFinder = ~/\[.*?\]/;
     static function fromCompilerFlagHelper(type:LogType, id:Null<String>, backup:PriorityList):PriorityList
     {
         // Use global log level if there's no id
         if (id == null)
             return fromGlobalCompilerFlag(type, backup);
         
-        // Use specific log level if one is set, Note: tasc[foo] uses log.tasc
-        final featureID = id.split('[')[0].toLowerCase();
-        final flagID = '$featureID.$type';
-        if (LoggerDefines.all.exists(flagID))
-            return fromString(LoggerDefines.all[flagID]);
+        final id = contextFinder.replace(id.toLowerCase(), "");
+        
+        // check if flags are cached for this id
+        final key = '$id.$type';
+        if (flagsByID.exists(key))
+        {
+            final flags = flagsByID[key];
+            if (flags == null)
+                return fromGlobalCompilerFlag(type, backup);
+            
+            return fromString(flags);
+        }
+        
+        // check various combos of the sub categories
+        final flag = checkAllFlags(id, type);
+        
+        // cache the flags for this id
+        if (flag != null)
+        {
+            flagsByID[key] = LoggerDefines.all[flag];
+            return fromString(flagsByID[key]);
+        }
         
         // Use global log level as backup
+        flagsByID[key] = null;
         return fromGlobalCompilerFlag(type, backup);
     }
+    
+    static function checkAllFlags(id:String, type:LogType):Null<String>
+    {
+        function check(id:String)
+        {
+            return LoggerDefines.all.exists('$id.$type');
+            // final found = LoggerDefines.all.exists('$id.$type');
+            // trace('$id.$type: $found');
+            // return found;
+        }
+        
+        // check the full id
+        final fullCheck = check(id);
+        if (fullCheck)
+            return '${id}${SUB_DELIMITER}${type}';
+        
+        var firstIndex = id.indexOf(SUB_DELIMITER);
+        if (firstIndex == -1)
+            return null;
+        
+        // check flags matching the sub id first
+        while(firstIndex != -1)
+        {
+            final subFlag = id.substr(firstIndex + 1);
+            if (check(subFlag))
+                return '${subFlag}${SUB_DELIMITER}${type}';
+            firstIndex = id.indexOf(SUB_DELIMITER, firstIndex+1);
+        }
+        
+        // remove last sub and try again
+        final lastIndex = id.lastIndexOf(SUB_DELIMITER);
+        return checkAllFlags(id.substr(0, lastIndex), type);
+    }
+    
+    
 }
 
 private enum abstract LogType(String) to String

--- a/test/src/Main.hx
+++ b/test/src/Main.hx
@@ -12,6 +12,7 @@ class Main
         log.setPriority(INFO);
         log.info("test log"); // Main: INFO:test log
         log.verbose("test log"); // ignored
+        log.sub("sub").verbose("test sub log"); // ignored
         log.sub("sub[context]").verbose("test sub log"); // ignored
         log.verbose.enabled = true;
         log.verbose("test log"); // Output: Main: VERBOSE:test log
@@ -30,6 +31,7 @@ class Main
         altLog.setPriority(INFO);
         altLog.info("test log"); // Alt: INFO:test log
         altLog.verbose("test log"); // ignored
+        altLog.sub("sub").verbose("test sub log"); // ignored
         altLog.sub("sub[context]").verbose("test sub log"); // ignored
         altLog.verbose.enabled = true;
         altLog.verbose("test log"); // Output: Alt: VERBOSE:test log

--- a/test/src/Main.hx
+++ b/test/src/Main.hx
@@ -3,6 +3,7 @@ import debug.Logger.log as gLog;
 class Main
 {
     static public var log = new debug.Logger("Main", WARN, ERROR); // logs warnings, throws exceptions on errors
+    static public var altLog = new debug.Logger("Alt", INFO, ERROR); // logs warnings, throws exceptions on errors
     static public function main():Void
     {
         log("--- Testing logs --- "); // Output: Main: test log
@@ -23,11 +24,29 @@ class Main
             gLog('exception caught: ${e.message}'); // Output: exception caught: Main[ERROR]:test log
         }
         
+        altLog("--- Testing Alt logs --- "); // Output: Alt: test log
+        altLog.warn("test log"); // Output: Alt: WARN:test log
+        altLog.info("test log"); // ignored
+        altLog.setPriority(INFO);
+        altLog.info("test log"); // Alt: INFO:test log
+        altLog.verbose("test log"); // ignored
+        altLog.sub("sub[context]").verbose("test sub log"); // ignored
+        altLog.verbose.enabled = true;
+        altLog.verbose("test log"); // Output: Alt: VERBOSE:test log
+        
         // subs
         log("--- Testing subs ---");
         final logSub = log.sub("sub[TEST]");
+        logSub.warn("test sub log");
+        logSub.info("test sub log");
         logSub.verbose("test sub log");
         logSub.sub("supersup").verbose("test supersub log");
+        
+        final altLogSub = altLog.sub("sub[TEST]");
+        altLogSub.warn("test sub log");
+        altLogSub.info("test sub log");
+        altLogSub.verbose("test sub log");
+        altLogSub.sub("supersup").verbose("test supersub log");
         
         // asserts
         log("--- Testing asserts ---");

--- a/test/src/Main.hx
+++ b/test/src/Main.hx
@@ -1,28 +1,36 @@
-import debug.Logger.log as gLog;
 import debug.Logger.assert as gAssert;
+import debug.Logger.log as gLog;
 class Main
 {
-    static public var log = new debug.Logger("Special", WARN, ERROR); // logs warnings, throws exceptions on errors
+    static public var log = new debug.Logger("Main", WARN, ERROR); // logs warnings, throws exceptions on errors
     static public function main():Void
     {
-        log("test log"); // Output: Special: test log
-        log.warn("test log"); // Output: Special: WARN:test log
+        log("--- Testing logs --- "); // Output: Main: test log
+        log.warn("test log"); // Output: Main: WARN:test log
         log.info("test log"); // ignored
         log.setPriority(INFO);
-        log.info("test log"); // Special: INFO:test log
+        log.info("test log"); // Main: INFO:test log
         log.verbose("test log"); // ignored
+        log.sub("sub[context]").verbose("test sub log"); // ignored
         log.verbose.enabled = true;
-        log.verbose("test log"); // Output: Special: VERBOSE:test log
+        log.verbose("test log"); // Output: Main: VERBOSE:test log
         try
         {
             log.error("test log"); // throws exception
         }
         catch(e)
         {
-            gLog('exception thrown: ${e.message}'); // Output: exception thrown: Special[ERROR]:test log
+            gLog('exception caught: ${e.message}'); // Output: exception caught: Main[ERROR]:test log
         }
         
+        // subs
+        log("--- Testing subs ---");
+        final logSub = log.sub("sub[TEST]");
+        logSub.verbose("test sub log");
+        logSub.sub("supersup").verbose("test supersub log");
+        
         // asserts
+        log("--- Testing asserts ---");
         log.verbose.assert(5 < 3);
         log.info.assert(5 < 3);
         log.warn.assert(5 < 3);
@@ -32,12 +40,12 @@ class Main
         }
         catch(e)
         {
-            gLog('exception thrown: ${e.message}'); // Output: exception thrown: Special[ERROR]:test log
+            gLog('exception caught: ${e.message}'); // Output: exception caught: Main[ERROR]:test log
         }
         // set custom logger
-        log.formatter = (priority, msg, ?pos) -> 'SPECIAL_$priority:$msg';
+        log.formatter = (priority, msg, ?pos) -> 'MAIN_$priority:$msg';
         log.error.throws = false;
-        log.error("test log"); // Output: SPECIAL_ERROR:test log
+        log.error("test log"); // Output: MAIN_ERROR:test log
         
         // Global logger (notice `import debug.Logger.log as gLog;`)
         gLog("test log");
@@ -50,7 +58,7 @@ class Main
         }
         catch(e)
         {
-            gLog('exception thrown: ${e.message}'); // Output: exception thrown: Special[ERROR]:test log
+            gLog('exception caught: ${e.message}'); // Output: exception caught: Main[ERROR]:test log
         }
     }
 }

--- a/test/test.hxml
+++ b/test/test.hxml
@@ -1,0 +1,11 @@
+--class-path src
+--class-path ../lib/
+--main Main
+-D main.log=warn
+-D sub.log=verbose
+--dce full
+-D analyzer-optimize
+-D logger.verboseMacroErrors
+# -D slim1.log=NONE
+# --js export/js/app.js
+--interp

--- a/test/test.hxml
+++ b/test/test.hxml
@@ -2,7 +2,9 @@
 --class-path ../lib/
 --main Main
 -D main.log=warn
+-D alt.log=info
 -D sub.log=verbose
+-D main.sub.log=warn
 --dce full
 -D analyzer-optimize
 -D logger.verboseMacroErrors

--- a/test/test.hxml
+++ b/test/test.hxml
@@ -3,7 +3,6 @@
 --main Main
 -D main.log=warn
 -D alt.log=info
--D sub.log=verbose
 -D main.sub.log=warn
 --dce full
 -D analyzer-optimize


### PR DESCRIPTION
Allows sub categories of other categories

```hx
final playerLog = new debug.Logger("Player", INFO);
final enemyLog = new debug.Logger("Enemy", INFO);

playerLog.sub("Sound").info("Playing jump sound"); // Player.Sound[INFO]: Playing jump sound
enemyLog.sub("Sound").warn("Not playing any sound"); // Enemy.Sound[WARN]: Not playing any sound
```

- Logs from sub categories are marked by delimiting "." characters
- Various categories can have the same sub, and each sub's log level will matches its direct parent's, by default. 
- Override the default level of every sound sub via `-D sound.log=warn`. 
- Override the default level of a specific category's sound sub via: `-D player.sound.log=warn`. This will override a sub's general log level

Also reuses existing log instances everywhere