### PR TITLE
Add variadic logging function to LoggerPriority

### DIFF
--- a/lib/debug/Logger.hx
+++ b/lib/debug/Logger.hx
@@ -2,6 +2,7 @@ package debug;
 
 import debug.Assert;
 import haxe.PosInfos;
+import haxe.macro.Expr;
 
 /**
  * Tool used to simplify the categorization of logs, and easily customize which type of logs
@@ -113,6 +114,12 @@ abstract Logger(LoggerRaw) from LoggerRaw
     {
         this.log(msg, pos);
     }
+
+    /** Variadic log, allows any number of arguments but cannot specify the pos */
+    macro public function v(expr:Expr, args:Array<Expr>):Expr
+    {
+        return Logger.logV(expr, args);
+    }
     
     /**
      * Creates a sub-category of this category, capable of having its own priorities.
@@ -132,6 +139,26 @@ abstract Logger(LoggerRaw) from LoggerRaw
         
         return list[fullID] = LoggerRaw.fromParent(subID, this);
     }
+    
+    /**
+     * Easy way to combine various args into a single string
+     */
+    static public function vFormat(args:Array<Any>, delim = ", "):String
+    {
+        return args.map(Std.string).join(delim);
+    }
+    
+    #if macro
+    /** Used by variadic log.v methods to make a single arg log with posInfos */
+    static public function logV(instance:Expr, args:Array<Expr>):Expr
+    {
+        return macro
+        {
+            @:pos(instance.pos)
+            $instance(debug.Logger.vFormat([$a{args}]));
+        };
+    }
+    #end
 }
 
 @:allow(debug.Logger)

--- a/lib/debug/LoggerPriority.hx
+++ b/lib/debug/LoggerPriority.hx
@@ -3,7 +3,6 @@ package debug;
 import debug.Logger;
 import haxe.PosInfos;
 import haxe.macro.Expr;
-import haxe.macro.ExprTools;
 
 @:forward(enabled, throws, assert, level)
 abstract LoggerPriority(LoggerPriorityRaw)
@@ -19,15 +18,10 @@ abstract LoggerPriority(LoggerPriorityRaw)
         this.log(msg, pos);
     }
 
-    function vFormat(args:Array<Any>, delim = ", "):String
-    {
-        return args.map(Std.string).join(delim);
-    }
-
     /** Variadic log, allows any number of arguments but cannot specify the pos */
     macro public function v(expr:ExprOf<Bool>, args:Array<Expr>):Expr
     {
-        return LoggerPriorityRaw.v(expr, args);
+        return Logger.logV(expr, args);
     }
     
     @:allow(debug.LoggerRaw)
@@ -75,15 +69,4 @@ private class LoggerPriorityRaw
         @:privateAccess
         parent.logIf(level, msg, pos);
     }
-    
-    #if macro
-    static public function v(instance:Expr, args:Array<Expr>):Expr
-    {
-        return macro
-        {
-            @:pos(instance.pos)
-            $instance(@:privateAccess $instance.vFormat([$a{args}]));
-        };
-    }
-    #end
 }

--- a/lib/debug/LoggerPriority.hx
+++ b/lib/debug/LoggerPriority.hx
@@ -18,12 +18,13 @@ abstract LoggerPriority(LoggerPriorityRaw)
     {
         this.log(msg, pos);
     }
-  	
-  	function vFormat(args:Array<Any>, delim = ", "):String
+
+    function vFormat(args:Array<Any>, delim = ", "):String
     {
         return args.map(Std.string).join(delim);
     }
-    
+
+    /** Variadic log, allows any number of arguments but cannot specify the pos */
     macro public function v(expr:ExprOf<Bool>, args:Array<Expr>):Expr
     {
         return LoggerPriorityRaw.v(expr, args);

--- a/lib/debug/LoggerPriority.hx
+++ b/lib/debug/LoggerPriority.hx
@@ -2,6 +2,8 @@ package debug;
 
 import debug.Logger;
 import haxe.PosInfos;
+import haxe.macro.Expr;
+import haxe.macro.ExprTools;
 
 @:forward(enabled, throws, assert, level)
 abstract LoggerPriority(LoggerPriorityRaw)
@@ -15,6 +17,16 @@ abstract LoggerPriority(LoggerPriorityRaw)
     inline function callPos(msg:Any, ?pos:PosInfos)
     {
         this.log(msg, pos);
+    }
+  	
+  	function vFormat(args:Array<Any>, delim = ", "):String
+    {
+        return args.map(Std.string).join(delim);
+    }
+    
+    macro public function v(expr:ExprOf<Bool>, args:Array<Expr>):Expr
+    {
+        return LoggerPriorityRaw.v(expr, args);
     }
     
     @:allow(debug.LoggerRaw)
@@ -62,4 +74,15 @@ private class LoggerPriorityRaw
         @:privateAccess
         parent.logIf(level, msg, pos);
     }
+    
+    #if macro
+    static public function v(instance:Expr, args:Array<Expr>):Expr
+    {
+        return macro
+        {
+            @:pos(instance.pos)
+            $instance(@:privateAccess $instance.vFormat([$a{args}]));
+        };
+    }
+    #end
 }

--- a/tests/bare/src/Main.hx
+++ b/tests/bare/src/Main.hx
@@ -16,6 +16,7 @@ class Main
         log.sub("sub[context]").verbose("test sub log"); // ignored
         log.verbose.enabled = true;
         log.verbose("test log"); // Output: Main: VERBOSE:test log
+        log.verbose.v(1, "a", true); // Output: Main: VERBOSE: 1, a, true
         try
         {
             log.error("test log"); // throws exception


### PR DESCRIPTION
Example:
```hx log.verbose.v(1, "a", true);```

Mimics the behavior of `trace(1, "a", true)` where you can pass any number of args but cannot specify the posInfos